### PR TITLE
Stops SIGABRT in UserGetComments.gotData() 

### DIFF
--- a/joindinapp/Classes/UserGetComments.m
+++ b/joindinapp/Classes/UserGetComments.m
@@ -39,133 +39,136 @@
 
 - (void)gotData:(NSObject *)obj {
 	UserCommentListModel *uclm = [[[UserCommentListModel alloc] init] autorelease];
-	
-	NSDictionary *d = (NSDictionary *)obj;
-	for (NSDictionary *comment in d) {
-		
-		if ([comment objectForKey:@"talk_id"] != nil) {
-			
-			UserTalkCommentDetailModel *ucdm;
-			ucdm = [[UserTalkCommentDetailModel alloc] init];
-			
-			if ([[comment objectForKey:@"talk_id"] isKindOfClass:[NSString class]]) {
-				ucdm.talkId = [[comment objectForKey:@"talk_id"] integerValue];
-			} else {
-				ucdm.talkId = 0;
-			}
-			
-			if ([[comment objectForKey:@"rating"] isKindOfClass:[NSString class]]) {
-				ucdm.rating = [[comment objectForKey:@"rating"] integerValue];
-			} else {
-				ucdm.rating = 0;
-			}
-			
-			if ([[comment objectForKey:@"comment_type"] isKindOfClass:[NSString class]]) {
-				ucdm.type = [comment objectForKey:@"comment_type"];
-			} else {
-				ucdm.type = @"comment";
-			}
-			
-			////
-			
-			if ([[comment objectForKey:@"comment"] isKindOfClass:[NSString class]]) {
-				ucdm.comment = [comment objectForKey:@"comment"];
-			} else {
-				ucdm.comment = @"";
-			}
-			
-			if ([[comment objectForKey:@"date_made"] isKindOfClass:[NSString class]]) {
-				ucdm.made = [NSDate dateWithTimeIntervalSince1970:[[comment objectForKey:@"date_made"] integerValue]];
-			} else {
-				ucdm.made = nil;
-			}
-			
-			if ([[comment objectForKey:@"user_id"] isKindOfClass:[NSString class]]) {
-				ucdm.uid = [[comment objectForKey:@"user_id"] integerValue];
-			} else {
-				ucdm.uid = 0;
-			}
-			
-			if ([[comment objectForKey:@"active"] isKindOfClass:[NSString class]]) {
-				ucdm.active = [[[comment objectForKey:@"active"] lowercaseString] isEqualToString:@"y"];
-			} else if ([[comment objectForKey:@"active"] isKindOfClass:[NSNumber class]]) {
-				ucdm.active = ([[comment objectForKey:@"active"] boolValue]);
-			} else {
-				NSLog(@"Can't recognise type %@", [[comment objectForKey:@"active"] class]);
-			}		
-			
-			if ([[comment objectForKey:@"ID"] isKindOfClass:[NSString class]]) {
-				ucdm.id = [[comment objectForKey:@"ID"] integerValue];
-			} else {
-				ucdm.id = 0;
-			}
-			
-			[uclm addComment:ucdm];
-			[ucdm release];
-			
-		} else if ([comment objectForKey:@"event_id"] != nil) {
-			
-			UserEventCommentDetailModel *ucdm;
-			ucdm = [[UserEventCommentDetailModel alloc] init];
-			
-			if ([[comment objectForKey:@"event_id"] isKindOfClass:[NSString class]]) {
-				ucdm.eventId = [[comment objectForKey:@"event_id"] integerValue];
-			} else {
-				ucdm.eventId = 0;
-			}
-			
-			if ([[comment objectForKey:@"cname"] isKindOfClass:[NSString class]]) {
-				ucdm.commentorName = [comment objectForKey:@"cname"];
-			} else {
-				ucdm.commentorName = @"Anonymous";
-			}
-			
-			/////
-			
-			if ([[comment objectForKey:@"comment"] isKindOfClass:[NSString class]]) {
-				ucdm.comment = [comment objectForKey:@"comment"];
-			} else {
-				ucdm.comment = @"";
-			}
-			
-			if ([[comment objectForKey:@"date_made"] isKindOfClass:[NSString class]]) {
-				ucdm.made = [NSDate dateWithTimeIntervalSince1970:[[comment objectForKey:@"date_made"] integerValue]];
-			} else {
-				ucdm.made = nil;
-			}
-			
-			if ([[comment objectForKey:@"user_id"] isKindOfClass:[NSString class]]) {
-				ucdm.uid = [[comment objectForKey:@"user_id"] integerValue];
-			} else {
-				ucdm.uid = 0;
-			}
-			
-			if ([[comment objectForKey:@"active"] isKindOfClass:[NSString class]]) {
-				ucdm.active = [[[comment objectForKey:@"active"] lowercaseString] isEqualToString:@"y"];
-			} else if ([[comment objectForKey:@"active"] isKindOfClass:[NSNumber class]]) {
-				ucdm.active = ([[comment objectForKey:@"active"] boolValue]);
-			} else {
-				NSLog(@"Can't recognise type %@", [[comment objectForKey:@"active"] class]);
-			}		
-			
-			if ([[comment objectForKey:@"ID"] isKindOfClass:[NSString class]]) {
-				ucdm.id = [[comment objectForKey:@"ID"] integerValue];
-			} else {
-				ucdm.id = 0;
-			}
-			
-			[uclm addComment:ucdm];
-			[ucdm release];
-			
-		} else {
-			
-			continue;
-			
-		}
-		
-	}
+    
+    if ([obj isKindOfClass:[NSDictionary class]]) {
+        NSDictionary *d = (NSDictionary *)obj;
+        for (NSObject *commentObj in d) {
+            if ([commentObj isKindOfClass:[NSDictionary class]]) {
+                NSDictionary *comment = (NSDictionary *)commentObj;
+                
+                if ([comment objectForKey:@"talk_id"] != nil) {
+                    
+                    UserTalkCommentDetailModel *ucdm;
+                    ucdm = [[UserTalkCommentDetailModel alloc] init];
+                    
+                    if ([[comment objectForKey:@"talk_id"] isKindOfClass:[NSString class]]) {
+                        ucdm.talkId = [[comment objectForKey:@"talk_id"] integerValue];
+                    } else {
+                        ucdm.talkId = 0;
+                    }
+                    
+                    if ([[comment objectForKey:@"rating"] isKindOfClass:[NSString class]]) {
+                        ucdm.rating = [[comment objectForKey:@"rating"] integerValue];
+                    } else {
+                        ucdm.rating = 0;
+                    }
+                    
+                    if ([[comment objectForKey:@"comment_type"] isKindOfClass:[NSString class]]) {
+                        ucdm.type = [comment objectForKey:@"comment_type"];
+                    } else {
+                        ucdm.type = @"comment";
+                    }
+                    
+                    ////
+                    
+                    if ([[comment objectForKey:@"comment"] isKindOfClass:[NSString class]]) {
+                        ucdm.comment = [comment objectForKey:@"comment"];
+                    } else {
+                        ucdm.comment = @"";
+                    }
+                    
+                    if ([[comment objectForKey:@"date_made"] isKindOfClass:[NSString class]]) {
+                        ucdm.made = [NSDate dateWithTimeIntervalSince1970:[[comment objectForKey:@"date_made"] integerValue]];
+                    } else {
+                        ucdm.made = nil;
+                    }
+                    
+                    if ([[comment objectForKey:@"user_id"] isKindOfClass:[NSString class]]) {
+                        ucdm.uid = [[comment objectForKey:@"user_id"] integerValue];
+                    } else {
+                        ucdm.uid = 0;
+                    }
+                    
+                    if ([[comment objectForKey:@"active"] isKindOfClass:[NSString class]]) {
+                        ucdm.active = [[[comment objectForKey:@"active"] lowercaseString] isEqualToString:@"y"];
+                    } else if ([[comment objectForKey:@"active"] isKindOfClass:[NSNumber class]]) {
+                        ucdm.active = ([[comment objectForKey:@"active"] boolValue]);
+                    } else {
+                        NSLog(@"Can't recognise type %@", [[comment objectForKey:@"active"] class]);
+                    }		
+                    
+                    if ([[comment objectForKey:@"ID"] isKindOfClass:[NSString class]]) {
+                        ucdm.id = [[comment objectForKey:@"ID"] integerValue];
+                    } else {
+                        ucdm.id = 0;
+                    }
+                    
+                    [uclm addComment:ucdm];
+                    [ucdm release];
+                    
+                } else if ([comment objectForKey:@"event_id"] != nil) {
+                    
+                    UserEventCommentDetailModel *ucdm;
+                    ucdm = [[UserEventCommentDetailModel alloc] init];
+                    
+                    if ([[comment objectForKey:@"event_id"] isKindOfClass:[NSString class]]) {
+                        ucdm.eventId = [[comment objectForKey:@"event_id"] integerValue];
+                    } else {
+                        ucdm.eventId = 0;
+                    }
+                    
+                    if ([[comment objectForKey:@"cname"] isKindOfClass:[NSString class]]) {
+                        ucdm.commentorName = [comment objectForKey:@"cname"];
+                    } else {
+                        ucdm.commentorName = @"Anonymous";
+                    }
+                    
+                    /////
+                    
+                    if ([[comment objectForKey:@"comment"] isKindOfClass:[NSString class]]) {
+                        ucdm.comment = [comment objectForKey:@"comment"];
+                    } else {
+                        ucdm.comment = @"";
+                    }
+                    
+                    if ([[comment objectForKey:@"date_made"] isKindOfClass:[NSString class]]) {
+                        ucdm.made = [NSDate dateWithTimeIntervalSince1970:[[comment objectForKey:@"date_made"] integerValue]];
+                    } else {
+                        ucdm.made = nil;
+                    }
+                    
+                    if ([[comment objectForKey:@"user_id"] isKindOfClass:[NSString class]]) {
+                        ucdm.uid = [[comment objectForKey:@"user_id"] integerValue];
+                    } else {
+                        ucdm.uid = 0;
+                    }
+                    
+                    if ([[comment objectForKey:@"active"] isKindOfClass:[NSString class]]) {
+                        ucdm.active = [[[comment objectForKey:@"active"] lowercaseString] isEqualToString:@"y"];
+                    } else if ([[comment objectForKey:@"active"] isKindOfClass:[NSNumber class]]) {
+                        ucdm.active = ([[comment objectForKey:@"active"] boolValue]);
+                    } else {
+                        NSLog(@"Can't recognise type %@", [[comment objectForKey:@"active"] class]);
+                    }		
+                    
+                    if ([[comment objectForKey:@"ID"] isKindOfClass:[NSString class]]) {
+                        ucdm.id = [[comment objectForKey:@"ID"] integerValue];
+                    } else {
+                        ucdm.id = 0;
+                    }
+                    
+                    [uclm addComment:ucdm];
+                    [ucdm release];
+                    
+                } else {
+                    
+                    continue;
+                    
+                }
+            }
+        }
+    }
 	[self.delegate gotUserComments:uclm error:nil];
-	
 }
 
 - (void)gotError:(APIError *)error {


### PR DESCRIPTION
Files modified:
  joindinapp/Classes/UserGetComments.m

This method expects to receive an object comprising an NSDictionary of
NSDictionaries. Due to a change in the API (I'm trying to find out
what the change is) the remote server currently returns an error so that
the first dictionary comprises a single key/value pair being an error
message. The gotData() method then tries to call objectForKey() on the
message which results in a SIGABRT since it is an NSString and not an
NSDictionary.

This patch adds some robustness to the call testing the class types
and only processing the data if it is an NSDictionary object.
