### PR TITLE
Fix posting new event comments

### DIFF
--- a/joindinapp/Classes/APICaller.m
+++ b/joindinapp/Classes/APICaller.m
@@ -222,22 +222,13 @@
 }
 
 - (void)gotResponse:(NSString *)responseString {
-	// Parse response
-	//NSLog(@"Response is %@", responseString);
+	// Not all responses contain body data
+	// eg 201, 204 and similar
+	// If there's a nil response, just pass it along anyway
 	SBJSON *jsonParser = [SBJSON new];
 	NSObject *obj = [jsonParser objectWithString:responseString error:NULL];
-	//NSLog(@"Got obj %@", obj);
 	[jsonParser release];
-	
-	if (obj == nil) {
-		if ([responseString isEqualToString:@"Invalid permissions!"]) {
-			[self gotError:[APIError APIErrorWithMsg:responseString type:ERR_CREDENTIALS]];
-		} else {
-			[self gotError:[APIError APIErrorWithMsg:responseString type:ERR_UNKNOWN]];
-		}
-	} else {
-		[self gotData:obj];
-	}
+	[self gotData:obj];
 }
 
 #pragma mark Override these

--- a/joindinapp/Classes/EventAddComment.m
+++ b/joindinapp/Classes/EventAddComment.m
@@ -17,32 +17,13 @@
 @implementation EventAddComment
 
 - (void)call:(EventDetailModel *)event comment:(NSString *)comment {
-//	NSMutableDictionary *params = [NSMutableDictionary dictionaryWithCapacity:4];
-//	[params setObject:[NSString stringWithFormat:@"%d", event.Id] forKey:@"event_id"];
-//	[params setObject:comment forKey:@"comment"];
-//	[self callAPI:@"event" action:@"addcomment" params:params needAuth:YES canCache:NO];
+	NSMutableDictionary *params = [NSMutableDictionary dictionaryWithCapacity:2];
+	[params setObject:comment forKey:@"comment"];
+	[self callAPI:event.commentsURI method:@"POST" params:params needAuth:YES canCache:NO];
 }
 
 - (void)gotData:(NSObject *)obj {
-	id _msg = [((NSDictionary *)obj) objectForKey:@"msg"];
-	
-	if ([_msg isKindOfClass:[NSString class]] && [_msg isEqualToString:@"Comment added!"]) {
-		[self.delegate gotAddedEventComment:nil];
-	} else {
-		// Detect if obj.msg is an array, and if so then collapse it
-		NSMutableString *msg = [NSMutableString stringWithCapacity:0];
-		if ([_msg isKindOfClass:[NSArray class]]) {
-			for(NSString *msgs in _msg) {
-				if ([msg length] > 1) {
-					[msg appendString:@", "];
-				}
-				[msg appendString:msgs];
-			}
-		} else {
-			[msg appendString:_msg];
-		}
-		[self gotError:[APIError APIErrorWithMsg:msg type:ERR_UNKNOWN]];
-	}
+	[self.delegate gotAddedEventComment:nil];
 }
 
 - (void)gotError:(APIError *)error {

--- a/joindinapp/Classes/EventCommentsViewController.m
+++ b/joindinapp/Classes/EventCommentsViewController.m
@@ -86,7 +86,12 @@
 		[alert show];
 		[alert release];
 	}
-	self.title = [NSString stringWithFormat:@"%d comments", (int) [self.comments getNumComments]];
+	int numComments = (int) [self.comments getNumComments];
+	NSMutableString *commentTitle = [NSMutableString stringWithFormat:@"%d comment", numComments];
+	if (numComments != 1) {
+		[commentTitle appendString:@"s"];
+	}
+	self.title = commentTitle;
 }
 
 - (void)gotAddedEventComment:(APIError *)error {

--- a/joindinapp/Classes/EventCommentsViewController.m
+++ b/joindinapp/Classes/EventCommentsViewController.m
@@ -118,6 +118,7 @@
 		[alert release];
 	} else {
 		// Reload comments
+		[self.provideCommentCell reset];
 		EventGetComments *e = [APICaller EventGetComments:self];
 		[e call:self.event];
 		self.title = @"Loading...";

--- a/joindinapp/Classes/NewEventCommentViewCell.h
+++ b/joindinapp/Classes/NewEventCommentViewCell.h
@@ -29,6 +29,7 @@
 - (IBAction) uiSubmitted:(id)sender;
 - (void) doStuff;
 - (void) textGotFocus:(NSNotification*)notification;
+- (void) reset;
 
 @end
 

--- a/joindinapp/Classes/NewEventCommentViewCell.m
+++ b/joindinapp/Classes/NewEventCommentViewCell.m
@@ -39,4 +39,10 @@
 	}
 }
 
+- (void) reset {
+    [self.uiActivity stopAnimating];
+    self.uiSubmit.hidden = NO;
+    self.uiComment.text = @"";
+}
+
 @end


### PR DESCRIPTION
Adding a new event comment now uses API v2.
Also fixes the pluralisation of the "1 comment/0 comments" view title.