### PR TITLE
Fix posting new talk comments

### DIFF
--- a/joindinapp/Classes/NewCommentViewCell.h
+++ b/joindinapp/Classes/NewCommentViewCell.h
@@ -44,6 +44,7 @@
 - (IBAction) uiRatingPressed:(id)sender;
 - (void) doStuff;
 - (void) textGotFocus:(NSNotification*)notification;
+- (void) reset;
 
 @end
 

--- a/joindinapp/Classes/NewCommentViewCell.m
+++ b/joindinapp/Classes/NewCommentViewCell.m
@@ -46,46 +46,23 @@
 }
 
 - (IBAction) uiRatingPressed:(id)sender {
-	if (self.uiRating1.state == 1) {
+	if (self.uiRating1.state == UIControlStateHighlighted) {
 		self.rating = 1;
-		[self.uiRating1 setImage:[UIImage imageNamed:@"rating-on.gif"]  forState:0];
-		[self.uiRating2 setImage:[UIImage imageNamed:@"rating-off.gif"] forState:0];
-		[self.uiRating3 setImage:[UIImage imageNamed:@"rating-off.gif"] forState:0];
-		[self.uiRating4 setImage:[UIImage imageNamed:@"rating-off.gif"] forState:0];
-		[self.uiRating5 setImage:[UIImage imageNamed:@"rating-off.gif"] forState:0];
 	}
-	if (self.uiRating2.state == 1) {
+	if (self.uiRating2.state == UIControlStateHighlighted) {
 		self.rating = 2;
-		[self.uiRating1 setImage:[UIImage imageNamed:@"rating-on.gif"]  forState:0];
-		[self.uiRating2 setImage:[UIImage imageNamed:@"rating-on.gif"]  forState:0];
-		[self.uiRating3 setImage:[UIImage imageNamed:@"rating-off.gif"] forState:0];
-		[self.uiRating4 setImage:[UIImage imageNamed:@"rating-off.gif"] forState:0];
-		[self.uiRating5 setImage:[UIImage imageNamed:@"rating-off.gif"] forState:0];
 	}
-	if (self.uiRating3.state == 1) {
+	if (self.uiRating3.state == UIControlStateHighlighted) {
 		self.rating = 3;
-		[self.uiRating1 setImage:[UIImage imageNamed:@"rating-on.gif"]  forState:0];
-		[self.uiRating2 setImage:[UIImage imageNamed:@"rating-on.gif"]  forState:0];
-		[self.uiRating3 setImage:[UIImage imageNamed:@"rating-on.gif"]  forState:0];
-		[self.uiRating4 setImage:[UIImage imageNamed:@"rating-off.gif"] forState:0];
-		[self.uiRating5 setImage:[UIImage imageNamed:@"rating-off.gif"] forState:0];
 	}
-	if (self.uiRating4.state == 1) {
+	if (self.uiRating4.state == UIControlStateHighlighted) {
 		self.rating = 4;
-		[self.uiRating1 setImage:[UIImage imageNamed:@"rating-on.gif"]  forState:0];
-		[self.uiRating2 setImage:[UIImage imageNamed:@"rating-on.gif"]  forState:0];
-		[self.uiRating3 setImage:[UIImage imageNamed:@"rating-on.gif"]  forState:0];
-		[self.uiRating4 setImage:[UIImage imageNamed:@"rating-on.gif"]  forState:0];
-		[self.uiRating5 setImage:[UIImage imageNamed:@"rating-off.gif"] forState:0];
 	}
-	if (self.uiRating5.state == 1) {
+	if (self.uiRating5.state == UIControlStateHighlighted) {
 		self.rating = 5;
-		[self.uiRating1 setImage:[UIImage imageNamed:@"rating-on.gif"]  forState:0];
-		[self.uiRating2 setImage:[UIImage imageNamed:@"rating-on.gif"]  forState:0];
-		[self.uiRating3 setImage:[UIImage imageNamed:@"rating-on.gif"]  forState:0];
-		[self.uiRating4 setImage:[UIImage imageNamed:@"rating-on.gif"]  forState:0];
-		[self.uiRating5 setImage:[UIImage imageNamed:@"rating-on.gif"]  forState:0];
 	}
+
+	[self setRatingImageState:self.rating];
 }
 
 // Poor-man's initialiser
@@ -101,6 +78,25 @@
 	if ([self.uiComment.text isEqualToString:@"Type comment..."]) {
 		self.uiComment.text = @"";
 	}
+}
+
+- (void) reset {
+	[self.uiActivity stopAnimating];
+	self.uiSubmit.hidden = NO;
+	self.uiComment.text = @"";
+	self.rating = 0;
+	[self setRatingImageState:self.rating];
+}
+
+- (void) setRatingImageState:(int)ratingValue {
+	NSString *off = @"rating-off.gif";
+	NSString *on = @"rating-on.gif";
+
+	[self.uiRating1 setImage:[UIImage imageNamed:(ratingValue > 0 ? on : off)] forState:UIControlStateNormal];
+	[self.uiRating2 setImage:[UIImage imageNamed:(ratingValue > 1 ? on : off)] forState:UIControlStateNormal];
+	[self.uiRating3 setImage:[UIImage imageNamed:(ratingValue > 2 ? on : off)] forState:UIControlStateNormal];
+	[self.uiRating4 setImage:[UIImage imageNamed:(ratingValue > 3 ? on : off)] forState:UIControlStateNormal];
+	[self.uiRating5 setImage:[UIImage imageNamed:(ratingValue > 4 ? on : off)] forState:UIControlStateNormal];
 }
 
 @end

--- a/joindinapp/Classes/TalkAddComment.m
+++ b/joindinapp/Classes/TalkAddComment.m
@@ -19,33 +19,14 @@
 
 - (void)call:(TalkDetailModel *)talk rating:(NSUInteger)rating comment:(NSString *)comment private:(BOOL)priv {
 	NSMutableDictionary *params = [NSMutableDictionary dictionaryWithCapacity:4];
-//	[params setObject:[NSString stringWithFormat:@"%d", talk.Id] forKey:@"talk_id"];
-	[params setObject:[NSString stringWithFormat:@"%d", (int) rating ] forKey:@"rating"];
+	[params setObject:[NSString stringWithFormat:@"%d", (int) rating] forKey:@"rating"];
 	[params setObject:comment forKey:@"comment"];
-	[params setObject:[NSString stringWithFormat:@"%d", priv   ] forKey:@"private"];
-	[self callAPI:@"talk" action:@"addcomment" params:params needAuth:YES canCache:NO];
+	[params setObject:[NSString stringWithFormat:@"%d", priv] forKey:@"private"];
+	[self callAPI:talk.commentsURI method:@"POST" params:params needAuth:YES canCache:NO];
 }
 
 - (void)gotData:(NSObject *)obj {
-	id _msg = [((NSDictionary *)obj) objectForKey:@"msg"];
-	
-	if ([_msg isKindOfClass:[NSString class]] && [_msg isEqualToString:@"Comment added!"]) {
-		[self.delegate gotAddedTalkComment:nil];
-	} else {
-		// Detect if obj.msg is an array, and if so then collapse it
-		NSMutableString *msg = [NSMutableString stringWithCapacity:0];
-		if ([_msg isKindOfClass:[NSArray class]]) {
-			for(NSString *msgs in _msg) {
-				if ([msg length] > 1) {
-					[msg appendString:@", "];
-				}
-				[msg appendString:msgs];
-			}
-		} else {
-			[msg appendString:_msg];
-		}
-		[self gotError:[APIError APIErrorWithMsg:msg type:ERR_UNKNOWN]];
-	}
+	[self.delegate gotAddedTalkComment:nil];
 }
 
 - (void)gotError:(APIError *)error {

--- a/joindinapp/Classes/TalkCommentsViewController.h
+++ b/joindinapp/Classes/TalkCommentsViewController.h
@@ -28,6 +28,7 @@
 	IBOutlet UITableViewCell *uiCell;
 	
 	BOOL commentsLoaded;
+	BOOL scrollToEnd;
 	
 }
 
@@ -41,6 +42,7 @@
 @property (nonatomic, retain) UITableViewCell *uiCell;
 
 @property (nonatomic, assign) BOOL commentsLoaded;
+@property (nonatomic, assign) BOOL scrollToEnd;
 
 - (void)submitComment:(NSString *)comment activityIndicator:(UIActivityIndicatorView *)activity rating:(NSUInteger)rating;
 - (void)focusNewComment;

--- a/joindinapp/Classes/TalkCommentsViewController.m
+++ b/joindinapp/Classes/TalkCommentsViewController.m
@@ -89,40 +89,21 @@
 }
 
 - (void)gotAddedTalkComment:(APIError *)error {
-	if (error != nil) {
-		UIAlertView *alert;
-		if (error.type == ERR_CREDENTIALS) {
-			alert = [[UIAlertView alloc] initWithTitle:@"Error" message:error.msg 
-											  delegate:self cancelButtonTitle:@"OK" otherButtonTitles:nil];
-		} else {
-			NSMutableString *msg = [NSMutableString stringWithCapacity:1];
-			[msg setString:@""];
-			if ([error.msg class] == [NSArray class]) {
-				for(NSString *eachMsg in (NSArray *)error.msg) {
-					[msg appendString:@", "];
-					[msg appendString:eachMsg];
-				}
-			} else {
-				[msg appendString:error.msg];
-			}
-			//NSLog(@"Error string %@", error.msg);
-			alert = [[UIAlertView alloc] initWithTitle:@"Error" message:msg 
-											  delegate:nil  cancelButtonTitle:@"OK" otherButtonTitles:nil];
-			// Reload comments
-			TalkGetComments *t = [APICaller TalkGetComments:self];
-			[t call:self.talk];
-		}
-		[alert show];
-		[alert release];
-	} else {
-		// Nip back to event screen
-		[self.navigationController popViewControllerAnimated:YES];
-		/* (doesn't seem to be re-init'ing the "Add comment" cell)
-		// Reload comments
-		TalkGetComments *t = [APICaller TalkGetComments:self];
-		[t call:self.talk];
-		 */
-	}
+    if (error != nil) {
+        UIAlertView *alert;
+        NSLog(@"Error string %@", (NSString *)error);
+        NSString *msg = @"There was a problem posting your comment";
+        alert = [[UIAlertView alloc] initWithTitle:@"Error" message:msg
+                                          delegate:nil  cancelButtonTitle:@"OK" otherButtonTitles:nil];
+        [alert show];
+        [alert release];
+    }
+
+    // Reload comments
+    [self.provideCommentCell reset];
+    TalkGetComments *t = [APICaller TalkGetComments:self];
+    [t call:self.talk];
+    self.title = @"Loading...";
 }
 
 - (void)alertView:(UIAlertView *)alertView didDismissWithButtonIndex:(NSInteger)buttonIndex {

--- a/joindinapp/Classes/TalkCommentsViewController.m
+++ b/joindinapp/Classes/TalkCommentsViewController.m
@@ -30,10 +30,12 @@
 @synthesize uiRating;
 @synthesize uiCell;
 @synthesize commentsLoaded;
+@synthesize scrollToEnd;
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
 	self.commentsLoaded = NO;
+	self.scrollToEnd = NO;
 	TalkGetComments *t = [APICaller TalkGetComments:self];
 	[t call:self.talk];
 	self.title = @"Loading...";
@@ -79,6 +81,10 @@
 		self.comments = tclm;
 		self.title = [NSString stringWithFormat:@"%d comments", (int) [self.comments getNumComments]];
 		[[self tableView] reloadData];
+		if (scrollToEnd) {
+			scrollToEnd = NO;
+			[self.tableView setContentOffset:CGPointMake(0, CGFLOAT_MAX)];
+		}
 	} else {
 		UIAlertView *alert;
 			alert = [[UIAlertView alloc] initWithTitle:@"Error" message:err.msg 
@@ -101,6 +107,7 @@
 
     // Reload comments
     [self.provideCommentCell reset];
+    self.scrollToEnd = YES;
     TalkGetComments *t = [APICaller TalkGetComments:self];
     [t call:self.talk];
     self.title = @"Loading...";

--- a/joindinapp/Classes/TalkDetailViewController.m
+++ b/joindinapp/Classes/TalkDetailViewController.m
@@ -47,7 +47,7 @@
 	self.uiTracks.hidden      = YES;
 
 	TalkGetDetail *t = [APICaller TalkGetDetail:self];
-	[t call:self.talk.uri];
+	[t call:self.talk.verboseURI];
 }
 
 -(void) gotTalkDetailData:(TalkDetailModel *)tdm error:(APIError *)error {

--- a/joindinapp/Classes/TalkGetComments.m
+++ b/joindinapp/Classes/TalkGetComments.m
@@ -33,7 +33,7 @@
 			tcdm.comment = @"";
 		}
 		
-		if ([[comment objectForKey:@"date_made"] isKindOfClass:[NSString class]]) {
+		if ([[comment objectForKey:@"created_date"] isKindOfClass:[NSString class]]) {
 			NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
 			[dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZ"];
 			tcdm.createdDate = [dateFormatter dateFromString:[comment objectForKey:@"created_date"]];

--- a/joindinapp/MainWindow.xib
+++ b/joindinapp/MainWindow.xib
@@ -1,63 +1,87 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="7.10">
+<archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
 	<data>
-		<int key="IBDocument.SystemTarget">768</int>
-		<string key="IBDocument.SystemVersion">10C540</string>
-		<string key="IBDocument.InterfaceBuilderVersion">740</string>
-		<string key="IBDocument.AppKitVersion">1038.25</string>
-		<string key="IBDocument.HIToolboxVersion">458.00</string>
+		<int key="IBDocument.SystemTarget">1296</int>
+		<string key="IBDocument.SystemVersion">14C1514</string>
+		<string key="IBDocument.InterfaceBuilderVersion">6751</string>
+		<string key="IBDocument.AppKitVersion">1344.72</string>
+		<string key="IBDocument.HIToolboxVersion">757.30</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">62</string>
+			<string key="NS.object.0">6736</string>
 		</object>
-		<object class="NSMutableArray" key="IBDocument.EditedObjectIDs">
-			<bool key="EncodedWithXMLCoder">YES</bool>
-			<integer value="2"/>
-			<integer value="23"/>
-		</object>
-		<object class="NSArray" key="IBDocument.PluginDependencies">
-			<bool key="EncodedWithXMLCoder">YES</bool>
+		<array key="IBDocument.IntegratedClassDependencies">
+			<string>IBProxyObject</string>
+			<string>IBUICustomObject</string>
+			<string>IBUIViewController</string>
+			<string>IBUIWindow</string>
+		</array>
+		<array key="IBDocument.PluginDependencies">
 			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-		</object>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<bool key="EncodedWithXMLCoder">YES</bool>
-			<object class="NSArray" key="dict.sortedKeys" id="0">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-			</object>
-			<object class="NSMutableArray" key="dict.values">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-			</object>
-		</object>
-		<object class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
-			<bool key="EncodedWithXMLCoder">YES</bool>
+		</array>
+		<dictionary class="NSMutableDictionary" key="IBDocument.Metadata"/>
+		<array class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
 			<object class="IBProxyObject" id="841351856">
 				<string key="IBProxiedObjectIdentifier">IBFilesOwner</string>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 			</object>
 			<object class="IBProxyObject" id="302016328">
 				<string key="IBProxiedObjectIdentifier">IBFirstResponder</string>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 			</object>
-			<object class="IBUICustomObject" id="664661524"/>
+			<object class="IBUICustomObject" id="664661524">
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
 			<object class="IBUIWindow" id="380026005">
 				<reference key="NSNextResponder"/>
 				<int key="NSvFlags">1316</int>
 				<object class="NSPSMatrix" key="NSFrameMatrix"/>
-				<string key="NSFrameSize">{320, 480}</string>
+				<string key="NSFrame">{{0, 20}, {320, 480}}</string>
 				<reference key="NSSuperview"/>
+				<reference key="NSWindow"/>
 				<object class="NSColor" key="IBUIBackgroundColor">
 					<int key="NSColorSpace">1</int>
 					<bytes key="NSRGB">MSAxIDEAA</bytes>
 				</object>
 				<bool key="IBUIOpaque">NO</bool>
 				<bool key="IBUIClearsContextBeforeDrawing">NO</bool>
-				<object class="IBUISimulatedStatusBarMetrics" key="IBUISimulatedStatusBarMetrics"/>
+				<object class="IBUISimulatedStatusBarMetrics" key="IBUISimulatedStatusBarMetrics" id="816908346"/>
+				<object class="IBUISimulatedSizeMetrics" key="IBUISimulatedDestinationMetrics">
+					<string key="IBUISimulatedSizeMetricsClass">IBUISimulatedFreeformSizeMetricsSentinel</string>
+					<string key="IBUIDisplayName">Freeform</string>
+				</object>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+				<bool key="IBUIResizesToFullScreen">YES</bool>
 			</object>
 			<object class="IBUIViewController" id="16388698">
-				<object class="IBUISimulatedStatusBarMetrics" key="IBUISimulatedStatusBarMetrics"/>
+				<reference key="IBUISimulatedStatusBarMetrics" ref="816908346"/>
+				<object class="IBUISimulatedOrientationMetrics" key="IBUISimulatedOrientationMetrics">
+					<int key="IBUIInterfaceOrientation">1</int>
+					<int key="interfaceOrientation">1</int>
+				</object>
+				<object class="IBUIScreenMetrics" key="IBUISimulatedDestinationMetrics">
+					<string key="IBUISimulatedSizeMetricsClass">IBUIScreenMetrics</string>
+					<string key="IBUITargetRuntime">IBCocoaTouchFramework</string>
+					<string key="IBUIDisplayName">iPhone 4-inch</string>
+					<object class="NSMutableDictionary" key="IBUINormalizedOrientationToSizeMap">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<array key="dict.sortedKeys">
+							<integer value="1"/>
+							<integer value="3"/>
+						</array>
+						<array key="dict.values">
+							<string>{320, 568}</string>
+							<string>{568, 320}</string>
+						</array>
+					</object>
+					<int key="IBUIType">2</int>
+				</object>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+				<bool key="IBUIHorizontal">NO</bool>
 			</object>
-		</object>
+		</array>
 		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<object class="NSMutableArray" key="connectionRecords">
-				<bool key="EncodedWithXMLCoder">YES</bool>
+			<array key="connectionRecords">
 				<object class="IBConnectionRecord">
 					<object class="IBCocoaTouchOutletConnection" key="connection">
 						<string key="label">delegate</string>
@@ -82,22 +106,19 @@
 					</object>
 					<int key="connectionID">24</int>
 				</object>
-			</object>
+			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
-				<object class="NSArray" key="orderedObjects">
-					<bool key="EncodedWithXMLCoder">YES</bool>
+				<array key="orderedObjects">
 					<object class="IBObjectRecord">
 						<int key="objectID">0</int>
-						<reference key="object" ref="0"/>
+						<array key="object" id="0"/>
 						<reference key="children" ref="1000"/>
 						<nil key="parent"/>
 					</object>
 					<object class="IBObjectRecord">
 						<int key="objectID">2</int>
 						<reference key="object" ref="380026005"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-						</object>
+						<array class="NSMutableArray" key="children"/>
 						<reference key="parent" ref="0"/>
 					</object>
 					<object class="IBObjectRecord">
@@ -121,229 +142,106 @@
 						<reference key="object" ref="16388698"/>
 						<reference key="parent" ref="0"/>
 					</object>
-				</object>
+				</array>
 			</object>
-			<object class="NSMutableDictionary" key="flattenedProperties">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<object class="NSArray" key="dict.sortedKeys">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-					<string>-1.CustomClassName</string>
-					<string>-2.CustomClassName</string>
-					<string>2.IBAttributePlaceholdersKey</string>
-					<string>2.IBEditorWindowLastContentRect</string>
-					<string>2.IBPluginDependency</string>
-					<string>23.CustomClassName</string>
-					<string>23.IBEditorWindowLastContentRect</string>
-					<string>23.IBPluginDependency</string>
-					<string>3.CustomClassName</string>
-					<string>3.IBPluginDependency</string>
-				</object>
-				<object class="NSMutableArray" key="dict.values">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-					<string>UIApplication</string>
-					<string>UIResponder</string>
-					<object class="NSMutableDictionary">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<reference key="dict.sortedKeys" ref="0"/>
-						<object class="NSMutableArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-						</object>
-					</object>
-					<string>{{673, 276}, {320, 480}}</string>
-					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-					<string>SplashScreenViewController</string>
-					<string>{{418, 254}, {320, 480}}</string>
-					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-					<string>joindinappAppDelegate</string>
-					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				</object>
-			</object>
-			<object class="NSMutableDictionary" key="unlocalizedProperties">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<reference key="dict.sortedKeys" ref="0"/>
-				<object class="NSMutableArray" key="dict.values">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-				</object>
-			</object>
+			<dictionary class="NSMutableDictionary" key="flattenedProperties">
+				<string key="-1.CustomClassName">UIApplication</string>
+				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="-2.CustomClassName">UIResponder</string>
+				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<dictionary class="NSMutableDictionary" key="2.IBAttributePlaceholdersKey"/>
+				<string key="2.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="23.CustomClassName">SplashScreenViewController</string>
+				<string key="23.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="3.CustomClassName">joindinappAppDelegate</string>
+				<string key="3.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+			</dictionary>
+			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
 			<nil key="activeLocalization"/>
-			<object class="NSMutableDictionary" key="localizations">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<reference key="dict.sortedKeys" ref="0"/>
-				<object class="NSMutableArray" key="dict.values">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-				</object>
-			</object>
+			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
 			<int key="maxID">24</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<bool key="EncodedWithXMLCoder">YES</bool>
+			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
 				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">Classes/JSON/NSObject+SBJSON.h</string>
+					<string key="className">SplashScreenViewController</string>
+					<string key="superclassName">UIViewController</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">pressedWebsite</string>
+						<string key="NS.object.0">id</string>
 					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">pressedWebsite</string>
+						<object class="IBActionInfo" key="NS.object.0">
+							<string key="name">pressedWebsite</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="outlets">
+						<string key="NS.key.0">uiLoading</string>
+						<string key="NS.object.0">UIActivityIndicatorView</string>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<string key="NS.key.0">uiLoading</string>
+						<object class="IBToOneOutletInfo" key="NS.object.0">
+							<string key="name">uiLoading</string>
+							<string key="candidateClassName">UIActivityIndicatorView</string>
+						</object>
+					</object>
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
 						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">Classes/JSON/SBJsonWriter.h</string>
+						<string key="minorKey">../Classes/SplashScreenViewController.h</string>
 					</object>
 				</object>
 				<object class="IBPartialClassDescription">
 					<string key="className">SplashScreenViewController</string>
-					<string key="superclassName">UIViewController</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">pressedWebsite</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">pressedWebsite</string>
+						<object class="IBActionInfo" key="NS.object.0">
+							<string key="name">pressedWebsite</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</object>
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
 						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">Classes/SplashScreenViewController.h</string>
+						<string key="minorKey">../Classes/SplashScreenViewController.m</string>
 					</object>
 				</object>
 				<object class="IBPartialClassDescription">
 					<string key="className">joindinappAppDelegate</string>
 					<string key="superclassName">NSObject</string>
-					<object class="NSMutableDictionary" key="outlets">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>navigationController</string>
-							<string>splashScreenViewController</string>
-							<string>window</string>
+					<dictionary class="NSMutableDictionary" key="outlets">
+						<string key="splashScreenViewController">SplashScreenViewController</string>
+						<string key="window">UIWindow</string>
+					</dictionary>
+					<dictionary class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<object class="IBToOneOutletInfo" key="splashScreenViewController">
+							<string key="name">splashScreenViewController</string>
+							<string key="candidateClassName">SplashScreenViewController</string>
 						</object>
-						<object class="NSMutableArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>UINavigationController</string>
-							<string>SplashScreenViewController</string>
-							<string>UIWindow</string>
+						<object class="IBToOneOutletInfo" key="window">
+							<string key="name">window</string>
+							<string key="candidateClassName">UIWindow</string>
 						</object>
-					</object>
+					</dictionary>
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
 						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">Classes/joindinappAppDelegate.h</string>
+						<string key="minorKey">../Classes/joindinappAppDelegate.h</string>
 					</object>
 				</object>
-			</object>
-			<object class="NSMutableArray" key="referencedPartialClassDescriptionsV3.2+">
-				<bool key="EncodedWithXMLCoder">YES</bool>
+			</array>
+			<array class="NSMutableArray" key="referencedPartialClassDescriptionsV3.2+">
 				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
+					<string key="className">UIActivityIndicatorView</string>
+					<string key="superclassName">UIView</string>
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
 						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSError.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSFileManager.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSKeyValueCoding.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSKeyValueObserving.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSKeyedArchiver.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSNetServices.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSObject.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSPort.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSRunLoop.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSStream.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSThread.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSURL.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSURLConnection.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">Foundation.framework/Headers/NSXMLParser.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UIAccessibility.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UINibLoading.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="1056567363">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UIResponder.h</string>
+						<string key="minorKey">UIKit.framework/Headers/UIActivityIndicatorView.h</string>
 					</object>
 				</object>
 				<object class="IBPartialClassDescription">
@@ -355,17 +253,20 @@
 					</object>
 				</object>
 				<object class="IBPartialClassDescription">
-					<string key="className">UINavigationController</string>
-					<string key="superclassName">UIViewController</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier" id="298880896">
+					<string key="className">UIGestureRecognizer</string>
+					<string key="superclassName">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
 						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UINavigationController.h</string>
+						<string key="minorKey">UIKit.framework/Headers/UIGestureRecognizer.h</string>
 					</object>
 				</object>
 				<object class="IBPartialClassDescription">
 					<string key="className">UIResponder</string>
 					<string key="superclassName">NSObject</string>
-					<reference key="sourceIdentifier" ref="1056567363"/>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBFrameworkSource</string>
+						<string key="minorKey">UIKit.framework/Headers/UIResponder.h</string>
+					</object>
 				</object>
 				<object class="IBPartialClassDescription">
 					<string key="className">UISearchBar</string>
@@ -385,28 +286,10 @@
 				</object>
 				<object class="IBPartialClassDescription">
 					<string key="className">UIView</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UITextField.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">UIView</string>
 					<string key="superclassName">UIResponder</string>
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
 						<string key="majorKey">IBFrameworkSource</string>
 						<string key="minorKey">UIKit.framework/Headers/UIView.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">UIViewController</string>
-					<reference key="sourceIdentifier" ref="298880896"/>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">UIViewController</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBFrameworkSource</string>
-						<string key="minorKey">UIKit.framework/Headers/UITabBarController.h</string>
 					</object>
 				</object>
 				<object class="IBPartialClassDescription">
@@ -425,20 +308,16 @@
 						<string key="minorKey">UIKit.framework/Headers/UIWindow.h</string>
 					</object>
 				</object>
-			</object>
+			</array>
 		</object>
 		<int key="IBDocument.localizationMode">0</int>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencyDefaults">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.iPhoneOS</string>
-			<integer value="768" key="NS.object.0"/>
-		</object>
+		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
+		<bool key="IBDocument.previouslyAttemptedUpgradeToXcode5">NO</bool>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.InterfaceBuilder3</string>
-			<integer value="3100" key="NS.object.0"/>
+			<integer value="4600" key="NS.object.0"/>
 		</object>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<string key="IBDocument.LastKnownRelativeProjectPath">joindinapp.xcodeproj</string>
 		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<string key="IBCocoaTouchPluginVersion">3.1</string>
 	</data>
 </archive>


### PR DESCRIPTION
In a similar vein to #18 - switches talk comments to use API v2.

The .xib change is to allow tapping of items at the bottom of the viewport (such as the rating control for comments) - frustratingly the single change was essentially to make the window full screen, but this resulted in a large number of XML changes according to Xcode...