### PR TITLE
Request 100 talks/event comments/talk comments at a time.

### DIFF
--- a/joindinapp/Classes/APICaller.h
+++ b/joindinapp/Classes/APICaller.h
@@ -38,6 +38,7 @@
 - (void)callAPI:(NSString *)type method:(NSString *)method params:(NSDictionary *)params needAuth:(BOOL)needAuth canCache:(BOOL)canCache;
 - (void)callAPI:(NSString *)type needAuth:(BOOL)needAuth canCache:(BOOL)canCache;
 - (void)callAPI:(NSString *)type params:(NSDictionary *)params needAuth:(BOOL)needAuth;
+- (void)callAPI:(NSString *)type params:(NSDictionary *)params needAuth:(BOOL)needAuth canCache:(BOOL)canCache;
 - (void)callAPI:(NSString *)type needAuth:(BOOL)needAuth;
 - (void)cancel;
 - (void)gotResponse:(NSString *)responseString;

--- a/joindinapp/Classes/APICaller.m
+++ b/joindinapp/Classes/APICaller.m
@@ -112,23 +112,23 @@
         [self.url setString:type]; // full URL supplied
     } else {
         [self.url setString:[NSString stringWithFormat:@"%@/%@", [self getApiUrl], type]];
+    }
 
-        if ([method isEqualToString:@"GET"]) {
-            // Add query string parameters
-            if ([self.url rangeOfString:@"?"].location == NSNotFound) {
-                [self.url appendString:@"?"];
-            } else {
-                [self.url appendString:@"&"];
-            }
-            NSMutableString *resultString = [[NSMutableString alloc] init];
-            for (NSString* key in [params allKeys]){
-                if ([resultString length] > 0) {
-                    [resultString appendString:@"&"];
-                }
-                [resultString appendFormat:@"%@=%@", key, [params objectForKey:key]];
-            }
-            [self.url appendString:resultString];
+    if ([method isEqualToString:@"GET"] && [params count] > 0) {
+        // Add query string parameters
+        if ([self.url rangeOfString:@"?"].location == NSNotFound) {
+            [self.url appendString:@"?"];
+        } else {
+            [self.url appendString:@"&"];
         }
+        NSMutableString *resultString = [[NSMutableString alloc] init];
+        for (NSString* key in [params allKeys]){
+            if ([resultString length] > 0) {
+                [resultString appendString:@"&"];
+            }
+            [resultString appendFormat:@"%@=%@", key, [params objectForKey:key]];
+        }
+        [self.url appendString:resultString];
     }
 
 //	if ((!canCache) || (![self checkCacheForRequest:self.reqJSON toUrl:self.url ignoreExpiry:NO])) {

--- a/joindinapp/Classes/APICaller.m
+++ b/joindinapp/Classes/APICaller.m
@@ -97,6 +97,10 @@
 	[self callAPI:type method:@"GET" params:params needAuth:needAuth canCache:YES];
 }
 
+- (void)callAPI:(NSString *)type params:(NSDictionary *)params needAuth:(BOOL)needAuth canCache:(BOOL)canCache {
+    [self callAPI:type method:@"GET" params:params needAuth:needAuth canCache:canCache];
+}
+
 - (void)callAPI:(NSString *)type needAuth:(BOOL)needAuth {
 	[self callAPI:type method:@"GET" params:[[NSDictionary alloc] init] needAuth:needAuth canCache:YES];
 }

--- a/joindinapp/Classes/EventGetComments.m
+++ b/joindinapp/Classes/EventGetComments.m
@@ -18,7 +18,7 @@
 @implementation EventGetComments
 
 - (void)call:(EventDetailModel *)event {
-	[self callAPI:event.commentsURI needAuth:NO canCache:YES];
+    [self callAPI:event.commentsURI params:[NSDictionary dictionaryWithObject:[[NSNumber alloc] initWithInt:100] forKey:@"resultsperpage"] needAuth:NO canCache:YES];
 }
 
 - (void)gotData:(NSObject *)obj {

--- a/joindinapp/Classes/EventGetTalks.m
+++ b/joindinapp/Classes/EventGetTalks.m
@@ -21,7 +21,7 @@
 
 - (void)call:(EventDetailModel *)_event {
 	self.event = _event;
-	[self callAPI:_event.talksURI needAuth:YES];
+    [self callAPI:_event.talksURI params:[NSDictionary dictionaryWithObject:[[NSNumber alloc] initWithInt:100] forKey:@"resultsperpage"] needAuth:YES];
 }
 
 - (void)gotData:(NSObject *)obj {

--- a/joindinapp/Classes/TalkGetComments.m
+++ b/joindinapp/Classes/TalkGetComments.m
@@ -17,7 +17,7 @@
 @implementation TalkGetComments
 
 - (void)call:(TalkDetailModel *)talk {
-    [self callAPI:talk.commentsURI needAuth:YES canCache:YES];
+    [self callAPI:talk.commentsURI params:[NSDictionary dictionaryWithObject:[[NSNumber alloc] initWithInt:100] forKey:@"resultsperpage"] needAuth:YES canCache:YES];
 }
 
 - (void)gotData:(NSObject *)obj {


### PR DESCRIPTION
This is the default of web2 presently. We should do some stuff around looping until all results have been fetched at some point, which would be neater.

The adding-GET-parameters has been moved to ensure that spurious `?` or `&` aren't added to a URL unnecessarily.