### PR TITLE
iOS 9 fixes

### DIFF
--- a/joindinapp/Classes/joindinappAppDelegate.m
+++ b/joindinapp/Classes/joindinappAppDelegate.m
@@ -31,7 +31,7 @@
 	// This is what happens when launched from a URL:
 	//[self application:application handleOpenURL:[NSURL URLWithString:@"joindin://event/110"]];
 	
-	[window addSubview:[splashScreenViewController view]];
+	[window setRootViewController:splashScreenViewController];
 	[window makeKeyAndVisible];
 	
 	// Go straight to an event: (note that you probably want to remove the joindin:// handler if you do this)

--- a/joindinapp/joindinapp-Info.plist
+++ b/joindinapp/joindinapp-Info.plist
@@ -37,13 +37,24 @@
 	<string>1.6</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>api.joind.in</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
+	<key>NSMainNibFile</key>
+	<string>MainWindow</string>
+	<key>joindInAPIURL</key>
+	<string>https://api.joind.in/v2.1</string>
 	<key>joindInOAuthClientID</key>
 	<string></string>
 	<key>joindInOAuthClientSecret</key>
 	<string></string>
-	<key>joindInAPIURL</key>
-	<string>https://api.joind.in/v2.1</string>
-	<key>NSMainNibFile</key>
-	<string>MainWindow</string>
 </dict>
 </plist>


### PR DESCRIPTION
These are the two initial fixes to build and run the application on iOS 9. Tested with Xcode 7 GM.

The exception in the `.plist` is as a result of the existing api.joind.in SSL certificate being [SHA1](https://shaaaaaaaaaaaaa.com/check/api.joind.in).