### PR TITLE
Storyboardify the event listing

### DIFF
--- a/joindinapp/Classes/EventListViewController.h
+++ b/joindinapp/Classes/EventListViewController.h
@@ -13,17 +13,19 @@
 
 #import "EventListModel.h"
 
-@interface EventListViewController : UITableViewController {
+@interface EventListViewController : UIViewController <UITableViewDelegate> {
 	EventListModel *confListData;
 	IBOutlet UIView *uiTableHeaderView;
 	IBOutlet UISegmentedControl *uiEventRange;
 	IBOutlet UITableViewCell *uiFetchingCell;
+    IBOutlet UITableView *eventListTableView;
 }
 
 @property(nonatomic, retain) EventListModel *confListData;
 @property(nonatomic, retain) UIView *uiTableHeaderView;
 @property(nonatomic, retain) UISegmentedControl *uiEventRange;
 @property(nonatomic, retain) UITableViewCell *uiFetchingCell;
+@property(nonatomic, retain) UITableView *eventListTableView;
 
 - (void)rangeChanged;
 

--- a/joindinapp/Classes/EventListViewController.h
+++ b/joindinapp/Classes/EventListViewController.h
@@ -16,17 +16,16 @@
 @interface EventListViewController : UIViewController <UITableViewDelegate> {
 	EventListModel *confListData;
 	IBOutlet UIView *uiTableHeaderView;
-	IBOutlet UISegmentedControl *uiEventRange;
 	IBOutlet UITableViewCell *uiFetchingCell;
     IBOutlet UITableView *eventListTableView;
 }
 
 @property(nonatomic, retain) EventListModel *confListData;
 @property(nonatomic, retain) UIView *uiTableHeaderView;
-@property(nonatomic, retain) UISegmentedControl *uiEventRange;
+@property(retain, nonatomic) IBOutlet UISegmentedControl *uiEventRange;
 @property(nonatomic, retain) UITableViewCell *uiFetchingCell;
 @property(nonatomic, retain) UITableView *eventListTableView;
 
-- (void)rangeChanged;
+- (IBAction)rangeChanged:(id)sender;
 
 @end

--- a/joindinapp/Classes/EventListViewController.m
+++ b/joindinapp/Classes/EventListViewController.m
@@ -83,7 +83,6 @@
 - (void)alertView:(UIAlertView *)alertView didDismissWithButtonIndex:(NSInteger)buttonIndex {
 	SettingsViewController *vc = [[SettingsViewController alloc] init];
 	[self.navigationController pushViewController:vc animated:YES];
-	[vc release];
 }
 
 
@@ -107,11 +106,7 @@
 #pragma mark Table view methods
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
-	if (self.confListData == nil) {
-		return 1;
-	} else {
-		return 1;
-	}
+    return 1;
 }
 
 
@@ -122,7 +117,6 @@
 		EventDetailModel *edm = [self.confListData getEventDetailModelAtIndex:[indexPath row]];
 		eventDetailViewController.event = edm;
 		[self.navigationController pushViewController:eventDetailViewController animated:YES];
-		[eventDetailViewController release];
 	}
 }
  
@@ -134,8 +128,7 @@
 	} else {
 		UITableViewCell *vc;
 		vc = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:nil];
-		[vc autorelease];
-		
+
 		EventDetailModel *edm = [self.confListData getEventDetailModelAtIndex:[indexPath row]];
 		
 		if (edm.attending) {
@@ -166,17 +159,11 @@
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
 	if (self.confListData == nil) {
-		return 1;
+		return 0;
 	} else {
 		return [self.confListData getNumEvents];
 	}
 }
-
-- (void)dealloc {
-    [eventListTableView release];
-    [super dealloc];
-}
-
 
 @end
 

--- a/joindinapp/Classes/EventListViewController.m
+++ b/joindinapp/Classes/EventListViewController.m
@@ -24,36 +24,17 @@
 @synthesize uiEventRange;
 @synthesize uiTableHeaderView;
 @synthesize uiFetchingCell;
+@synthesize eventListTableView;
 
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-    // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
-    // self.navigationItem.rightBarButtonItem = self.editButtonItem;
-	self.title = @"Events";
-	
-	self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Settings" style:UIBarButtonItemStylePlain target:self action:@selector(btnPressed)];
-	
-	NSArray* nibViews =  [[NSBundle mainBundle] loadNibNamed:@"EventListView" owner:self options:nil];
-	self.uiTableHeaderView = [nibViews objectAtIndex: 1];	
-	((UITableView *)[self view]).tableHeaderView = self.uiTableHeaderView;
-	
-	[self.uiEventRange addTarget:self
-						  action:@selector(rangeChanged)
-				forControlEvents:UIControlEventValueChanged];
-	
-	
-}
-
-- (void)btnPressed {
-	SettingsViewController *vc = [[SettingsViewController alloc] init];
-	[self.navigationController pushViewController:vc animated:YES];
-	[vc release];	
+    [self.uiEventRange addTarget:self action:@selector(rangeChanged) forControlEvents:UIControlEventValueChanged];
 }
 
 - (void)rangeChanged {
 	self.confListData = nil;
-	[(UITableView *)[self view] reloadData];
+	[self.eventListTableView reloadData];
 	
 	EventGetList *e = [APICaller EventGetList:self];
 
@@ -95,7 +76,7 @@
 		}
 		
 		self.confListData = eventListData;
-		[(UITableView *)[self view] reloadData];
+		[self.eventListTableView reloadData];
 	}
 }
 
@@ -111,30 +92,6 @@
 	[self rangeChanged];
 }
 
-/*
-- (void)viewDidAppear:(BOOL)animated {
-    [super viewDidAppear:animated];
-}
-*/
-/*
-- (void)viewWillDisappear:(BOOL)animated {
-	[super viewWillDisappear:animated];
-}
-*/
-/*
-- (void)viewDidDisappear:(BOOL)animated {
-	[super viewDidDisappear:animated];
-}
-*/
-
-/*
- // Override to allow orientations other than the default portrait orientation.
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-	// Return YES for supported orientations.
-	return (interfaceOrientation == UIInterfaceOrientationPortrait);
-}
-*/
-
 - (void)didReceiveMemoryWarning {
 	// Releases the view if it doesn't have a superview.
     [super didReceiveMemoryWarning];
@@ -146,7 +103,6 @@
 	// Release anything that can be recreated in viewDidLoad or on demand.
 	// e.g. self.myOutlet = nil;
 }
-
 
 #pragma mark Table view methods
 
@@ -217,6 +173,7 @@
 }
 
 - (void)dealloc {
+    [eventListTableView release];
     [super dealloc];
 }
 

--- a/joindinapp/Classes/EventListViewController.m
+++ b/joindinapp/Classes/EventListViewController.m
@@ -21,18 +21,11 @@
 @implementation EventListViewController
 
 @synthesize confListData;
-@synthesize uiEventRange;
 @synthesize uiTableHeaderView;
 @synthesize uiFetchingCell;
 @synthesize eventListTableView;
 
-- (void)viewDidLoad {
-    [super viewDidLoad];
-
-    [self.uiEventRange addTarget:self action:@selector(rangeChanged) forControlEvents:UIControlEventValueChanged];
-}
-
-- (void)rangeChanged {
+- (IBAction)rangeChanged:(id)sender {
 	self.confListData = nil;
 	[self.eventListTableView reloadData];
 	
@@ -88,7 +81,7 @@
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
-	[self rangeChanged];
+    [self rangeChanged:self.uiEventRange];
 }
 
 - (void)didReceiveMemoryWarning {

--- a/joindinapp/Classes/EventListViewController.m
+++ b/joindinapp/Classes/EventListViewController.m
@@ -96,6 +96,19 @@
 	// e.g. self.myOutlet = nil;
 }
 
+// NOTE: This is temporary only until the Settings view has been brought
+// over to the storyboard
+- (BOOL)shouldPerformSegueWithIdentifier:(NSString *)identifier sender:(id)sender {
+    if ([identifier isEqualToString:@"settingsSegue"]) {
+        SettingsViewController *vc = [[SettingsViewController alloc] init];
+        [self.navigationController pushViewController:vc animated:YES];
+
+        return NO;
+    }
+
+    return YES;
+}
+
 #pragma mark Table view methods
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {

--- a/joindinapp/Classes/joindinappAppDelegate.h
+++ b/joindinapp/Classes/joindinappAppDelegate.h
@@ -13,7 +13,7 @@
 
 #import "SplashScreenViewController.h"
 
-@interface joindinappAppDelegate : NSObject <UIApplicationDelegate> {
+@interface joindinappAppDelegate : UIResponder <UIApplicationDelegate> {
     
     UIWindow *window;
     IBOutlet SplashScreenViewController *splashScreenViewController;

--- a/joindinapp/Classes/joindinappAppDelegate.m
+++ b/joindinapp/Classes/joindinappAppDelegate.m
@@ -62,15 +62,5 @@
     return NO;
 }
 
-#pragma mark -
-#pragma mark Memory management
-
-- (void)dealloc {
-	[splashScreenViewController release];
-	[window release];
-	[super dealloc];
-}
-
-
 @end
 

--- a/joindinapp/Classes/joindinappAppDelegate.m
+++ b/joindinapp/Classes/joindinappAppDelegate.m
@@ -24,19 +24,9 @@
 #pragma mark -
 #pragma mark Application lifecycle
 
-- (void)applicationDidFinishLaunching:(UIApplication *)application {    
-    
-    // Override point for customization after app launch    
-	
-	// This is what happens when launched from a URL:
-	//[self application:application handleOpenURL:[NSURL URLWithString:@"joindin://event/110"]];
-	
-	[window setRootViewController:splashScreenViewController];
-	[window makeKeyAndVisible];
-	
-	// Go straight to an event: (note that you probably want to remove the joindin:// handler if you do this)
-	//[splashScreenViewController gotoEventScreenWithEventId:142];
-
+- (BOOL)applicationDidFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Override point for customization after app launch
+    return YES;
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application {

--- a/joindinapp/MainStoryboard.storyboard
+++ b/joindinapp/MainStoryboard.storyboard
@@ -50,6 +50,9 @@
                     <navigationItem key="navigationItem" title="joind.in" id="EL2-zN-wPt">
                         <barButtonItem key="rightBarButtonItem" title="Settings" id="i14-Fg-axb">
                             <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <connections>
+                                <segue destination="hKw-NB-CKe" kind="show" id="sot-cX-m0j"/>
+                            </connections>
                         </barButtonItem>
                     </navigationItem>
                     <connections>
@@ -60,6 +63,25 @@
             </objects>
             <point key="canvasLocation" x="1457" y="275"/>
         </scene>
+        <!--Settings-->
+        <scene sceneID="DlN-OQ-ncy">
+            <objects>
+                <viewController title="Settings" id="hKw-NB-CKe" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="MA4-Jk-yI4"/>
+                        <viewControllerLayoutGuide type="bottom" id="c8u-vF-epU"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Pt2-uJ-ZTC">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                    <navigationItem key="navigationItem" title="Settings" id="KKh-xg-HyW"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ZWy-j1-QL2" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1457" y="1085"/>
+        </scene>
         <!--Navigation Controller-->
         <scene sceneID="sOO-w5-UGn">
             <objects>
@@ -68,6 +90,7 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="0aZ-6c-UbR">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <color key="barTintColor" red="0.0" green="0.4823529412" blue="0.59215686270000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <textAttributes key="titleTextAttributes">
                             <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -82,5 +105,26 @@
             </objects>
             <point key="canvasLocation" x="645" y="275"/>
         </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="78a-Zg-Nem">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Aa6-nq-rfh" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="iDY-sE-4lB">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="hKw-NB-CKe" kind="relationship" relationship="rootViewController" id="kcl-l8-tiw"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="CZG-lk-EAU" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="759" y="1085"/>
+        </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="sot-cX-m0j"/>
+    </inferredMetricsTieBreakers>
 </document>

--- a/joindinapp/MainStoryboard.storyboard
+++ b/joindinapp/MainStoryboard.storyboard
@@ -125,26 +125,5 @@
             </objects>
             <point key="canvasLocation" x="-1951" y="-297"/>
         </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="78a-Zg-Nem">
-            <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Aa6-nq-rfh" sceneMemberID="viewController">
-                    <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="iDY-sE-4lB">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <nil name="viewControllers"/>
-                    <connections>
-                        <segue destination="hKw-NB-CKe" kind="relationship" relationship="rootViewController" id="kcl-l8-tiw"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="CZG-lk-EAU" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-1837" y="513"/>
-        </scene>
     </scenes>
-    <inferredMetricsTieBreakers>
-        <segue reference="sot-cX-m0j"/>
-    </inferredMetricsTieBreakers>
 </document>

--- a/joindinapp/MainStoryboard.storyboard
+++ b/joindinapp/MainStoryboard.storyboard
@@ -28,6 +28,9 @@
                                     <segment title="Upcoming"/>
                                 </segments>
                                 <color key="tintColor" red="0.0" green="0.4823529412" blue="0.59215686270000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <connections>
+                                    <action selector="rangeChanged:" destination="CkU-hI-Ogq" eventType="valueChanged" id="4cP-tU-vxT"/>
+                                </connections>
                             </segmentedControl>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="ft7-Sq-YRm">
                                 <rect key="frame" x="0.0" y="135" width="600" height="465"/>
@@ -58,6 +61,7 @@
                     </navigationItem>
                     <connections>
                         <outlet property="eventListTableView" destination="ft7-Sq-YRm" id="ua2-TX-6c5"/>
+                        <outlet property="uiEventRange" destination="UhN-TK-WzU" id="s8e-H0-dfB"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="TEC-Kh-tPY" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/joindinapp/MainStoryboard.storyboard
+++ b/joindinapp/MainStoryboard.storyboard
@@ -27,6 +27,7 @@
                                     <segment title="Hot"/>
                                     <segment title="Upcoming"/>
                                 </segments>
+                                <color key="tintColor" red="0.0" green="0.4823529412" blue="0.59215686270000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </segmentedControl>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="ft7-Sq-YRm">
                                 <rect key="frame" x="0.0" y="135" width="600" height="465"/>
@@ -61,7 +62,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="TEC-Kh-tPY" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1457" y="275"/>
+            <point key="canvasLocation" x="-1139" y="-297"/>
         </scene>
         <!--Settings-->
         <scene sceneID="DlN-OQ-ncy">
@@ -74,13 +75,28 @@
                     <view key="view" contentMode="scaleToFill" id="Pt2-uJ-ZTC">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" lineBreakMode="tailTruncation" numberOfLines="0" minimumFontSize="10" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="bFz-Vl-HSi">
+                                <rect key="frame" x="16" y="72" width="568" height="56"/>
+                                <string key="text">Sign in using your joind.in username and password in order to leave comments with your name, track which events you are attending and personalise your event listings</string>
+                                <fontDescription key="fontDescription" name="Helvetica" family="Helvetica" pointSize="12"/>
+                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="bFz-Vl-HSi" firstAttribute="trailing" secondItem="Pt2-uJ-ZTC" secondAttribute="trailingMargin" id="Hdq-Py-AfW"/>
+                            <constraint firstItem="bFz-Vl-HSi" firstAttribute="leading" secondItem="Pt2-uJ-ZTC" secondAttribute="leadingMargin" id="b2l-Mf-AJt"/>
+                            <constraint firstAttribute="centerX" secondItem="bFz-Vl-HSi" secondAttribute="centerX" id="cGC-Ff-poz"/>
+                            <constraint firstItem="bFz-Vl-HSi" firstAttribute="top" secondItem="MA4-Jk-yI4" secondAttribute="bottom" constant="8" id="y2m-7x-0JR"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Settings" id="KKh-xg-HyW"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ZWy-j1-QL2" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1457" y="1085"/>
+            <point key="canvasLocation" x="-1139" y="513"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="sOO-w5-UGn">
@@ -103,7 +119,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Gdh-12-EYt" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="645" y="275"/>
+            <point key="canvasLocation" x="-1951" y="-297"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="78a-Zg-Nem">
@@ -121,7 +137,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="CZG-lk-EAU" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="759" y="1085"/>
+            <point key="canvasLocation" x="-1837" y="513"/>
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>

--- a/joindinapp/MainStoryboard.storyboard
+++ b/joindinapp/MainStoryboard.storyboard
@@ -4,5 +4,83 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
-    <scenes/>
+    <scenes>
+        <!--joind.in-->
+        <scene sceneID="STz-AK-lW1">
+            <objects>
+                <viewController title="joind.in" id="CkU-hI-Ogq" customClass="EventListViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="xcS-Sb-4kX"/>
+                        <viewControllerLayoutGuide type="bottom" id="NiW-7U-D89"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="LiC-Y8-HBL">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <subviews>
+                            <segmentedControl opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="1" translatesAutoresizingMaskIntoConstraints="NO" id="UhN-TK-WzU">
+                                <rect key="frame" x="160" y="86" width="280" height="29"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="280" id="GVm-Om-fwe"/>
+                                </constraints>
+                                <segments>
+                                    <segment title="Past"/>
+                                    <segment title="Hot"/>
+                                    <segment title="Upcoming"/>
+                                </segments>
+                            </segmentedControl>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="ft7-Sq-YRm">
+                                <rect key="frame" x="0.0" y="135" width="600" height="465"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <connections>
+                                    <outlet property="dataSource" destination="CkU-hI-Ogq" id="nyo-vc-8me"/>
+                                    <outlet property="delegate" destination="CkU-hI-Ogq" id="3E0-pE-lVV"/>
+                                </connections>
+                            </tableView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="width" secondItem="ft7-Sq-YRm" secondAttribute="width" id="45o-X7-Chh"/>
+                            <constraint firstAttribute="centerX" secondItem="ft7-Sq-YRm" secondAttribute="centerX" id="4Zc-Xy-dE5"/>
+                            <constraint firstItem="UhN-TK-WzU" firstAttribute="top" secondItem="xcS-Sb-4kX" secondAttribute="bottom" constant="22" id="IxP-YY-3ab"/>
+                            <constraint firstAttribute="centerX" secondItem="UhN-TK-WzU" secondAttribute="centerX" id="XTs-F9-Nwc"/>
+                            <constraint firstItem="ft7-Sq-YRm" firstAttribute="top" secondItem="UhN-TK-WzU" secondAttribute="bottom" constant="21" id="c88-e0-cIg"/>
+                            <constraint firstItem="NiW-7U-D89" firstAttribute="top" secondItem="ft7-Sq-YRm" secondAttribute="bottom" id="q2f-NQ-3Vq"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="joind.in" id="EL2-zN-wPt">
+                        <barButtonItem key="rightBarButtonItem" title="Settings" id="i14-Fg-axb">
+                            <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="eventListTableView" destination="ft7-Sq-YRm" id="ua2-TX-6c5"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="TEC-Kh-tPY" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1457" y="275"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="sOO-w5-UGn">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Jmd-ID-UJl" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="0aZ-6c-UbR">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <color key="barTintColor" red="0.0" green="0.4823529412" blue="0.59215686270000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <textAttributes key="titleTextAttributes">
+                            <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        </textAttributes>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="CkU-hI-Ogq" kind="relationship" relationship="rootViewController" id="LEM-mr-tIy"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Gdh-12-EYt" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="645" y="275"/>
+        </scene>
+    </scenes>
 </document>

--- a/joindinapp/MainStoryboard.storyboard
+++ b/joindinapp/MainStoryboard.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Jmd-ID-UJl">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
         <!--joind.in-->
@@ -55,7 +56,7 @@
                         <barButtonItem key="rightBarButtonItem" title="Settings" id="i14-Fg-axb">
                             <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             <connections>
-                                <segue destination="hKw-NB-CKe" kind="show" id="sot-cX-m0j"/>
+                                <segue destination="hKw-NB-CKe" kind="show" identifier="settingsSegue" id="sot-cX-m0j"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -80,9 +81,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" lineBreakMode="tailTruncation" numberOfLines="0" minimumFontSize="10" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="bFz-Vl-HSi">
-                                <rect key="frame" x="16" y="72" width="568" height="56"/>
-                                <string key="text">Sign in using your joind.in username and password in order to leave comments with your name, track which events you are attending and personalise your event listings</string>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" text="Dummy Settings placeholder" lineBreakMode="tailTruncation" numberOfLines="0" minimumFontSize="10" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="bFz-Vl-HSi">
+                                <rect key="frame" x="20" y="72" width="560" height="14"/>
                                 <fontDescription key="fontDescription" name="Helvetica" family="Helvetica" pointSize="12"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>

--- a/joindinapp/SplashScreenView.xib
+++ b/joindinapp/SplashScreenView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1514" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" promptedForUpgradeToXcode5="NO">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14C1514" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment version="1536" identifier="iOS"/>
         <development version="5000" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SplashScreenViewController">

--- a/joindinapp/joindinapp-Info.plist
+++ b/joindinapp/joindinapp-Info.plist
@@ -37,17 +37,15 @@
 	<string>1.6.1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSMainNibFile</key>
-	<string>MainWindow</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Your location is required to show your current position on the map</string>
+	<key>UIMainStoryboardFile</key>
+	<string>MainStoryboard</string>
 	<key>joindInAPIURL</key>
 	<string>https://api.joind.in/v2.1</string>
-	<key>UIMainStoryboardFile</key>
-	<string></string>
 	<key>joindInOAuthClientID</key>
 	<string></string>
 	<key>joindInOAuthClientSecret</key>
 	<string></string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Your location is required to show your current position on the map</string>
 </dict>
 </plist>

--- a/joindinapp/joindinapp.xcodeproj/project.pbxproj
+++ b/joindinapp/joindinapp.xcodeproj/project.pbxproj
@@ -112,8 +112,8 @@
 		28C286E10D94DF7D0034E888 /* EventListViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 28C286E00D94DF7D0034E888 /* EventListViewController.m */; };
 		28F335F11007B36200424DE2 /* EventListView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28F335F01007B36200424DE2 /* EventListView.xib */; };
 		9B2CF77A1BA763BF00F64075 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B2CF7791BA763BF00F64075 /* CoreLocation.framework */; };
-		9BF8C70B1C215CDC004333C3 /* icon_87.png in Resources */ = {isa = PBXBuildFile; fileRef = 9BF8C70A1C215CDC004333C3 /* icon_87.png */; };
 		9BF8C7091C215C08004333C3 /* MainStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9BF8C7081C215C08004333C3 /* MainStoryboard.storyboard */; };
+		9BF8C70B1C215CDC004333C3 /* icon_87.png in Resources */ = {isa = PBXBuildFile; fileRef = 9BF8C70A1C215CDC004333C3 /* icon_87.png */; };
 		A028B23A17FF580300B86718 /* Default~iphone.png in Resources */ = {isa = PBXBuildFile; fileRef = A028B23117FF580300B86718 /* Default~iphone.png */; };
 		A028B23B17FF580300B86718 /* Default@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = A028B23217FF580300B86718 /* Default@2x.png */; };
 		A028B23C17FF580300B86718 /* Default-568h@2x~iphone.png in Resources */ = {isa = PBXBuildFile; fileRef = A028B23317FF580300B86718 /* Default-568h@2x~iphone.png */; };
@@ -299,8 +299,8 @@
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* joindinapp-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "joindinapp-Info.plist"; plistStructureDefinitionIdentifier = "com.apple.xcode.plist.structure-definition.iphone.info-plist"; sourceTree = "<group>"; };
 		9B2CF7791BA763BF00F64075 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
-		9BF8C70A1C215CDC004333C3 /* icon_87.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = icon_87.png; sourceTree = "<group>"; };
 		9BF8C7081C215C08004333C3 /* MainStoryboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = MainStoryboard.storyboard; sourceTree = "<group>"; };
+		9BF8C70A1C215CDC004333C3 /* icon_87.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = icon_87.png; sourceTree = "<group>"; };
 		A028B23117FF580300B86718 /* Default~iphone.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default~iphone.png"; sourceTree = "<group>"; };
 		A028B23217FF580300B86718 /* Default@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default@2x.png"; sourceTree = "<group>"; };
 		A028B23317FF580300B86718 /* Default-568h@2x~iphone.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x~iphone.png"; sourceTree = "<group>"; };
@@ -891,6 +891,7 @@
 				PRODUCT_NAME = joindinapp;
 				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Adhoc;
 		};
@@ -912,6 +913,7 @@
 				PRODUCT_NAME = joindinapp;
 				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -931,6 +933,7 @@
 				PRODUCT_NAME = joindinapp;
 				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/joindinapp/main.m
+++ b/joindinapp/main.m
@@ -12,7 +12,6 @@
 //
 
 #import <UIKit/UIKit.h>
-
 #import "joindinappAppDelegate.h"
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
This moves to using the storyboard for the events listing. There's a segue to a dummy Settings screen which we override in code temporarily (to use the old Settings screen until it's moved to the storyboard), and I've enabled display on both iPhone and iPad as well.